### PR TITLE
Result based errors for Parse and Tokenize.

### DIFF
--- a/lib/db.ml
+++ b/lib/db.ml
@@ -6,6 +6,8 @@ type dbError =
   | DatabaseExists
   | KeyNotFound
   | FileReadError
+  | TokenizationError of string
+  | SyntaxError of string
 
 type keyDirEntry = {filename: string; timestamp: int; value_size: int; pos: int}
 
@@ -39,6 +41,10 @@ let string_of_dberror err =
       "FileReadError - Error with file read."
   | DatabaseExists ->
       "DatabaseExists - Database already exists."
+  | TokenizationError err ->
+      "TokenizationError - " ^ err
+  | SyntaxError err ->
+      "SyntaxError - " ^ err
 
 let create_dir path =
   if not (Sys.file_exists path) then Sys.mkdir path 0o777 (* Full Permissions *)

--- a/lib/db.mli
+++ b/lib/db.mli
@@ -6,6 +6,8 @@ type dbError =
   | DatabaseExists
   | KeyNotFound
   | FileReadError
+  | TokenizationError of string
+  | SyntaxError of string
 
 type keyDirEntry = {filename: string; timestamp: int; value_size: int; pos: int}
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -150,4 +150,6 @@ and parse_program (tokens : Tokenize.token list) (trees : ast list) =
       let isnt_nop (tree : ast) = match tree with NOP -> false | _ -> true in
       parse_program unconsumed_tokens (List.filter isnt_nop (trees @ [tree]))
 
-let parse (tokens : Tokenize.token list) : ast list = parse_program tokens []
+let parse (tokens : Tokenize.token list) : (ast list, Db.dbError) result =
+  try Result.ok (parse_program tokens [])
+  with Failure err -> Result.error (Db.SyntaxError err)

--- a/lib/parse.mli
+++ b/lib/parse.mli
@@ -8,6 +8,6 @@ type ast =
   | LIST
   | NOP
 
-val parse : Tokenize.token list -> ast list
+val parse : Tokenize.token list -> (ast list, Db.dbError) result
 
 val string_of_ast : ast -> string

--- a/lib/repl.ml
+++ b/lib/repl.ml
@@ -32,9 +32,17 @@ let string_of_result (result_result : (Eval.evaluationResult, Db.dbError) result
 let run_repl () =
   let rec run_repl_rec (db_session_opt : Db.dbSession option) : unit =
     let line = get_statement () in
-    let tokens = Tokenize.tokenize_string line in
-    let asts = Parse.parse tokens in
-    let result = Eval.evaluate_asts asts db_session_opt in
+    let result =
+      match Tokenize.tokenize_string line with
+      | Ok tokens -> (
+        match Parse.parse tokens with
+        | Ok asts ->
+            Eval.evaluate_asts asts db_session_opt
+        | Error err ->
+            Result.error err )
+      | Error err ->
+          Result.error err
+    in
     print_endline (string_of_result result) ;
     let new_db_session =
       match result with

--- a/lib/tokenize.ml
+++ b/lib/tokenize.ml
@@ -62,7 +62,7 @@ let string_of_token (input : token) =
   | NOP_TOKEN ->
       "NOP"
 
-let tokenize_string (str : string) =
+let tokenize_string (str : string) : (token list, Db.dbError) result =
   let rec chew_string (str_as_list : char list) (buffer : char list)
       (tokens : token list) : token list =
     match str_as_list with
@@ -88,4 +88,8 @@ let tokenize_string (str : string) =
         handle_quote tail (buffer @ [c]) tokens
   in
   let isnt_nop e = match e with NOP_TOKEN -> false | _ -> true in
-  List.filter isnt_nop (chew_string (List.of_seq (String.to_seq str)) [] [])
+  try
+    Result.ok
+      (List.filter isnt_nop
+         (chew_string (List.of_seq (String.to_seq str)) [] []) )
+  with Failure err -> Result.error (Db.TokenizationError err)

--- a/test/evalTest.ml
+++ b/test/evalTest.ml
@@ -2,8 +2,11 @@ open OUnit2
 
 let test_eval_create _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string "CREATE \"test_eval_create.db\";")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "CREATE \"test_eval_create.db\";" ) ) )
   in
   let eval_ast ast = Result.get_ok (PostMixDB.Eval.evaluate_ast ast None) in
   match List.map eval_ast asts with
@@ -14,10 +17,12 @@ let test_eval_create _ =
 
 let test_eval_multiple_trees _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string
-         "CREATE \"test_eval_multiple_trees.db\"; PUT \"key\" \"value\"; GET \
-          \"key\"" )
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "CREATE \"test_eval_multiple_trees.db\"; PUT \"key\" \"value\"; \
+                GET \"key\"" ) ) )
   in
   match Result.get_ok (PostMixDB.Eval.evaluate_asts asts None) with
   | STRING_RESULT str ->
@@ -28,15 +33,19 @@ let test_eval_multiple_trees _ =
 let test_eval_multiple_trees_open _ =
   ignore
     (PostMixDB.Eval.evaluate_asts
-       (PostMixDB.Parse.parse
-          (PostMixDB.Tokenize.tokenize_string
-             "CREATE \"test_eval_multiple_trees_open.db\";" ) )
+       (Result.get_ok
+          (PostMixDB.Parse.parse
+             (Result.get_ok
+                (PostMixDB.Tokenize.tokenize_string
+                   "CREATE \"test_eval_multiple_trees_open.db\";" ) ) ) )
        None ) ;
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string
-         "OPEN \"test_eval_multiple_trees_open.db\";LIST;PUT \"key\" \
-          \"value\"; GET \"key\"" )
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "OPEN \"test_eval_multiple_trees_open.db\";LIST;PUT \"key\" \
+                \"value\"; GET \"key\"" ) ) )
   in
   match Result.get_ok (PostMixDB.Eval.evaluate_asts asts None) with
   | STRING_RESULT str ->
@@ -46,20 +55,22 @@ let test_eval_multiple_trees_open _ =
 
 let test_eval_multiple_trees_list _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string
-         "CREATE \"test_eval_multiple_trees_list.db\";\n\
-         \        PUT \"key01\" \"value\";\n\
-         \        PUT \"key02\" \"value\";\n\
-         \        PUT \"key03\" \"value\";\n\
-         \        PUT \"key04\" \"value\";\n\
-         \        PUT \"key05\" \"value\";\n\
-         \        PUT \"key06\" \"value\";\n\
-         \        PUT \"key07\" \"value\";\n\
-         \        PUT \"key08\" \"value\";\n\
-         \        PUT \"key09\" \"value\";\n\
-         \        PUT \"key10\" \"value\";\n\
-         \        LIST" )
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "CREATE \"test_eval_multiple_trees_list.db\";\n\
+               \        PUT \"key01\" \"value\";\n\
+               \        PUT \"key02\" \"value\";\n\
+               \        PUT \"key03\" \"value\";\n\
+               \        PUT \"key04\" \"value\";\n\
+               \        PUT \"key05\" \"value\";\n\
+               \        PUT \"key06\" \"value\";\n\
+               \        PUT \"key07\" \"value\";\n\
+               \        PUT \"key08\" \"value\";\n\
+               \        PUT \"key09\" \"value\";\n\
+               \        PUT \"key10\" \"value\";\n\
+               \        LIST" ) ) )
   in
   match Result.get_ok (PostMixDB.Eval.evaluate_asts asts None) with
   | INFO_STRING_RESULT str ->
@@ -71,22 +82,24 @@ let test_eval_multiple_trees_list _ =
 
 let test_eval_multiple_trees_delete _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string
-         "CREATE \"test_eval_multiple_trees_delete.db\";\n\
-         \        PUT \"key01\" \"value\";\n\
-         \        PUT \"key02\" \"value\";\n\
-         \        PUT \"key03\" \"value\";\n\
-         \        PUT \"key04\" \"value\";\n\
-         \        PUT \"key05\" \"value\";\n\
-         \        PUT \"key06\" \"value\";\n\
-         \        PUT \"key07\" \"value\";\n\
-         \        PUT \"key08\" \"value\";\n\
-         \        PUT \"key09\" \"value\";\n\
-         \        PUT \"key10\" \"value\";\n\
-         \         DELETE \"key01\";\n\
-         \         DELETE \"key02\";\n\
-         \                 LIST" )
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "CREATE \"test_eval_multiple_trees_delete.db\";\n\
+               \        PUT \"key01\" \"value\";\n\
+               \        PUT \"key02\" \"value\";\n\
+               \        PUT \"key03\" \"value\";\n\
+               \        PUT \"key04\" \"value\";\n\
+               \        PUT \"key05\" \"value\";\n\
+               \        PUT \"key06\" \"value\";\n\
+               \        PUT \"key07\" \"value\";\n\
+               \        PUT \"key08\" \"value\";\n\
+               \        PUT \"key09\" \"value\";\n\
+               \        PUT \"key10\" \"value\";\n\
+               \         DELETE \"key01\";\n\
+               \         DELETE \"key02\";\n\
+               \                 LIST" ) ) )
   in
   match Result.get_ok (PostMixDB.Eval.evaluate_asts asts None) with
   | INFO_STRING_RESULT str ->

--- a/test/parseTest.ml
+++ b/test/parseTest.ml
@@ -2,45 +2,58 @@ open OUnit2
 
 let test_parse _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string "OPEN \"database.db\" ;")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string "OPEN \"database.db\" ;") ) )
   in
   let strs = List.map PostMixDB.Parse.string_of_ast asts in
   assert_equal strs ["OPEN:\n\tSTRING database.db\n"]
 
 let test_parse_nested _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string "OPEN GET GET \"KEY\";")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string "OPEN GET GET \"KEY\";") ) )
   in
   let strs = List.map PostMixDB.Parse.string_of_ast asts in
   assert_equal strs ["OPEN:\n\tGET:\n\t\tGET:\n\t\t\tSTRING KEY\n"]
 
 let test_parse_immediate_semicolon _ =
   let asts =
-    PostMixDB.Parse.parse (PostMixDB.Tokenize.tokenize_string "LIST;")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok (PostMixDB.Tokenize.tokenize_string "LIST;")) )
   in
   let strs = List.map PostMixDB.Parse.string_of_ast asts in
   assert_equal strs ["LIST\n"]
 
 let test_parse_multiple_trees _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string "OPEN \"database.db\" GET \"key\"")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string
+               "OPEN \"database.db\" GET \"key\"" ) ) )
   in
   let strs = List.map PostMixDB.Parse.string_of_ast asts in
   assert_equal strs ["OPEN:\n\tSTRING database.db\n"; "GET:\n\tSTRING key\n"]
 
 let test_parse_put _ =
   let asts =
-    PostMixDB.Parse.parse
-      (PostMixDB.Tokenize.tokenize_string "PUT \"key\" \"value\" ;")
+    Result.get_ok
+      (PostMixDB.Parse.parse
+         (Result.get_ok
+            (PostMixDB.Tokenize.tokenize_string "PUT \"key\" \"value\" ;") ) )
   in
   let strs = List.map PostMixDB.Parse.string_of_ast asts in
   assert_equal strs ["PUT:\n\tSTRING key\n\tSTRING value\n"]
 
 let test_parse_missing_operand _ =
-  let parse =
-   fun () -> PostMixDB.Parse.parse (PostMixDB.Tokenize.tokenize_string "OPEN ;")
+  let err =
+    Result.get_error
+      (PostMixDB.Parse.parse
+         (Result.get_ok (PostMixDB.Tokenize.tokenize_string "OPEN ;")) )
   in
-  assert_raises (Failure "Invalid Non-terminal Statement") parse
+  assert_equal (PostMixDB.Db.SyntaxError "Invalid Non-terminal Statement") err

--- a/test/tokenizeTest.ml
+++ b/test/tokenizeTest.ml
@@ -3,14 +3,16 @@ open OUnit2
 let test_open_tokenize _ =
   let strs =
     List.map PostMixDB.Tokenize.string_of_token
-      (PostMixDB.Tokenize.tokenize_string "OPEN \"database.db\"")
+      (Result.get_ok
+         (PostMixDB.Tokenize.tokenize_string "OPEN \"database.db\"") )
   in
   assert_equal strs ["OPEN"; "STRING(database.db)"]
 
 let test_brackets_tokenize _ =
   let strs =
     List.map PostMixDB.Tokenize.string_of_token
-      (PostMixDB.Tokenize.tokenize_string "OPEN (\"database.db\")")
+      (Result.get_ok
+         (PostMixDB.Tokenize.tokenize_string "OPEN (\"database.db\")") )
   in
   assert_equal strs
     ["OPEN"; "OPEN_BRACKET"; "STRING(database.db)"; "CLOSE_BRACKET"]
@@ -18,32 +20,34 @@ let test_brackets_tokenize _ =
 let test_single_token_tokenize _ =
   let strs =
     List.map PostMixDB.Tokenize.string_of_token
-      (PostMixDB.Tokenize.tokenize_string "LIST")
+      (Result.get_ok (PostMixDB.Tokenize.tokenize_string "LIST"))
   in
   assert_equal strs ["LIST"]
 
 let test_put_tokenize _ =
   let strs =
     List.map PostMixDB.Tokenize.string_of_token
-      (PostMixDB.Tokenize.tokenize_string
-         "PUT \"THIS IS A KEY\" \"THIS IS A VALUE\"" )
+      (Result.get_ok
+         (PostMixDB.Tokenize.tokenize_string
+            "PUT \"THIS IS A KEY\" \"THIS IS A VALUE\"" ) )
   in
   assert_equal strs ["PUT"; "STRING(THIS IS A KEY)"; "STRING(THIS IS A VALUE)"]
 
 let test_tokenize_semicolon _ =
   let strs =
     List.map PostMixDB.Tokenize.string_of_token
-      (PostMixDB.Tokenize.tokenize_string "LIST;")
+      (Result.get_ok (PostMixDB.Tokenize.tokenize_string "LIST;"))
   in
   assert_equal strs ["LIST"; "SEMICOLON"]
 
 let test_tokenize_invalid_token _ =
-  let f = fun () -> PostMixDB.Tokenize.tokenize_string "BILLY" in
-  assert_raises (Failure "Invalid Token") f
+  let err = Result.get_error (PostMixDB.Tokenize.tokenize_string "BILLY") in
+  assert_equal (PostMixDB.Db.TokenizationError "Invalid Token") err
 
 let test_tokenize_string_not_closed _ =
-  let f =
-   fun () ->
-    PostMixDB.Tokenize.tokenize_string "PUT \"THIS IS A KEY\" \"THIS IS A VALUE"
+  let err =
+    Result.get_error
+      (PostMixDB.Tokenize.tokenize_string
+         "PUT \"THIS IS A KEY\" \"THIS IS A VALUE" )
   in
-  assert_raises (Failure "String never closed") f
+  assert_equal (PostMixDB.Db.TokenizationError "String never closed") err


### PR DESCRIPTION
Changed the exposed functions for Parse and Tokenize to use Result for errors. Modified REPL and Tests to handle this change.